### PR TITLE
Bump for blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,21 @@ storage and analysis.
 
 ### Topbeat
 
- Topbeat is a lightweight way to gather CPU, memory, and other per-process and
+ A lightweight way to gather CPU, memory, and other per-process and
  system wide data, then ship it to Elasticsearch to analyze the results.
+
+### Packetbeat
+
+An open source project that is designed to provide
+real‑time analytics for web, database, and other network protocols.
+
+### Dockerbeat
+
+A lightweight, open source shipper for docker daemon data. Dockerbeat polls
+the Docker Engine daemon, and sends cpu, network, memory, and host
+information to Logstash for further parsing and enrichment or to Elasticsearch
+for centralized storage and analysis.
+
 
 # Usage
 
@@ -37,7 +50,7 @@ to http://<kibana-public-ip>/dashboards and load up the topbeat dash and you're
 in business!
 
 Note: This demo dashboard also ships with visualizations we are not yet
-populating for Packetbeat and winlogbeat beats. These are TODO:
+populating for winlogbeat beats.
 
 ## Contact information
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4,15 +4,17 @@ services:
     charm: "cs:trusty/kibana-12"
     num_units: 1
     expose: true
+    options:
+      dashboards: beats
     annotations:
-      "gui-x": "979"
-      "gui-y": "731"
+      "gui-x": "987"
+      "gui-y": "900"
   elasticsearch:
     charm: "cs:trusty/elasticsearch-15"
     num_units: 1
     annotations:
       "gui-x": "680"
-      "gui-y": "735"
+      "gui-y": "900"
   filebeat:
     charm: "cs:trusty/filebeat-2"
     annotations:
@@ -23,10 +25,24 @@ services:
     annotations:
       "gui-x": "352"
       "gui-y": "854"
+  packetbeat:
+    charm: "cs:~containers/trusty/packetbeat-4"
+    annotations:
+      "gui-x": "352"
+      "gui-y": "1054"
+  dockerbeat:
+    charm: "cs:~containers/trusty/dockerbeat-1"
+    annotations:
+      "gui-x": "352"
+      "gui-y": "1254"
 relations:
   - - "kibana:rest"
     - "elasticsearch:client"
   - - "filebeat:elasticsearch"
     - "elasticsearch:client"
   - - "topbeat:elasticsearch"
+    - "elasticsearch:client"
+  - - "dockerbeat:elasticsearch"
+    - "elasticsearch:client"
+  - - "packetbeat:elasticsearch"
     - "elasticsearch:client"


### PR DESCRIPTION
Adds Packetbeat and Dockerbeat to the default beats core formation. Additionally updates the README to call out the new beats.
